### PR TITLE
shell: remove absolute paths from ln, rm, mv and mkdir

### DIFF
--- a/src/shell.ml
+++ b/src/shell.ml
@@ -510,21 +510,21 @@ let which = Shell_internal.which
 let ln ?s ?f src dst =
   let s = Option.map s ~f:(fun () -> "-s") in
   let f = Option.map f ~f:(fun () -> "-f") in
-  run "/bin/ln" (List.filter_map ~f:Fn.id [ s; f ] @ [ "-n"; "--"; src; dst ])
+  run "ln" (List.filter_map ~f:Fn.id [ s; f ] @ [ "-n"; "--"; src; dst ])
 ;;
 
 let rm ?r ?f path =
   let r = Option.map r ~f:(fun () -> "-r") in
   let f = Option.map f ~f:(fun () -> "-f") in
-  run "/bin/rm" (List.filter_map ~f:Fn.id [ r; f; Some "--"; Some path ])
+  run "rm" (List.filter_map ~f:Fn.id [ r; f; Some "--"; Some path ])
 ;;
 
-let mv src dst = run "/bin/mv" [ "--"; src; dst ]
+let mv src dst = run "mv" [ "--"; src; dst ]
 
 let mkdir ?p ?perm path =
   let p = Option.map p ~f:(fun () -> "-p") in
   let mode = Option.map perm ~f:(sprintf "--mode=%o") in
-  run "/bin/mkdir" (List.filter_map ~f:Fn.id [ p; mode; Some "--"; Some path ])
+  run "mkdir" (List.filter_map ~f:Fn.id [ p; mode; Some "--"; Some path ])
 ;;
 
 (* TODO: Deal with atomicity  *)


### PR DESCRIPTION
This fails executing on NixOS, where these binaries do not exist there (but in $PATH).

```
[ perf record: Captured and wrote 0.232 MB /run/user/1000/magic_trace.tmp.d532fd/perf.data ] [ Snapshot taken. ]
[ Finished recording. ]
[ Decoding, this takes a while... ]
Visit https://magic-trace.org/ and open trace.fxt to view trace. (monitor.ml.Error (Failure "fork_exec: Process not found /bin/rm")
 ("Raised at Stdlib.failwith in file \"stdlib.ml\", line 29, characters 17-33"
  "Called from Unix_extended.fork_exec in file \"unix_extended/src/unix_extended.ml\", line 162, characters 16-67"
  "Called from Low_level_process.internal_create_process in file \"low_level_process/src/low_level_process.ml\", line 43, characters 14-276"
  "Re-raised at Low_level_process.internal_create_process in file \"low_level_process/src/low_level_process.ml\", line 67, characters 4-11"
  "Called from Low_level_process.create in file \"low_level_process/src/low_level_process.ml\", line 342, characters 4-98"
  "Called from Low_level_process.run in file \"low_level_process/src/low_level_process.ml\", line 422, characters 14-301"
  "Called from Shell.Process.run_k.(fun) in file \"src/shell.ml\", line 181, characters 16-37"
  "Called from Magic_trace_lib__Trace.Make_commands.record_flags.(fun) in file \"src/trace.ml\", line 548, characters 26-57"
  "Called from Async_kernel__Monitor.Exported_for_scheduler.schedule'.upon_work_fill_i in file \"src/monitor.ml\", line 299, characters 42-51"
  "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 167, characters 6-47"
  "Caught by monitor finally"))
```